### PR TITLE
Add variable to track which langs in code blocks should be formatted

### DIFF
--- a/lazy-ruff.el
+++ b/lazy-ruff.el
@@ -75,6 +75,8 @@
 (defvar lazy-ruff-only-check-region nil
   "When non-nil (e.g. t), only lint the code in a region without formatting fixes.")
 
+(defvar lazy-ruff-org-src-languages '("python")
+  "Defines which languages in code blocks are eligible for formatting and linting")
 
 (defun lazy-ruff-run-commands (temp-file only-format only-check)
   "Run the appropriate ruff commands on TEMP-FILE.
@@ -113,7 +115,7 @@ Ensures cursor position is maintained.  Requires `ruff` in system's PATH."
                           (goto-char (org-element-property :end element))
                           (search-backward "#+END_SRC")
                           (line-beginning-position))))
-      (if (not (string= lang "python"))
+      (if (not (member lang lazy-ruff-org-src-languages))
           (message "The source block is not Python")
         (with-temp-file temp-file (insert code))
 	(lazy-ruff-run-commands temp-file (eq lazy-ruff-only-format-block t) (eq lazy-ruff-only-check-block t))


### PR DESCRIPTION
I just converted a project to use `ruff` rather than `black` for formatting, and started using this excellent tool to help me format my buffers.

One pain point which came up was that I had a number of code blocks in org files that I wanted formatted as python, but which had a `:language` property that wasn't just the string "python", but rather "jupyter-python".

The language variable of code blocks can be just about anything, so this pull request adds a list of languages that should be considered pythons. Then, instead of checking whether the languages exactly matches the string "python", the code instead checks for membership in this list.

I've kept the original value of the list as just `("python")`, so the default behavior is unchanged. Users who want to change which languages are considered pythons should modify the value of the variable.